### PR TITLE
Add basic web frontend with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.build/
+.eggs/
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.log
+fastf1/testing/
+fastf1/tests/
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir . && \
+    pip install --no-cache-dir -r webapp/requirements.txt
+CMD ["uvicorn", "webapp.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Licensing B.V.
 ## Web Frontend
 
 This repository includes a small FastAPI based web application that lets you
-load historical race data and display a demo live timing stream. To start the
+load historical race data, fetch practice lap times and display a demo live
+timing stream. To start the
 service using Docker run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -72,3 +72,15 @@ FastF1 and this website are unofficial and are not associated in any way with
 the Formula 1 companies. F1, FORMULA ONE, FORMULA 1, FIA FORMULA ONE WORLD
 CHAMPIONSHIP, GRAND PRIX and related marks are trade marks of Formula One
 Licensing B.V.
+
+## Web Frontend
+
+This repository includes a small FastAPI based web application that lets you
+load historical race data and display a demo live timing stream. To start the
+service using Docker run:
+
+```bash
+docker compose up --build
+```
+
+The UI will be available at http://localhost:8000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      PYTHONUNBUFFERED: "1"
+    restart: unless-stopped

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -1,0 +1,58 @@
+import asyncio
+from pathlib import Path
+
+from fastapi import (
+    FastAPI,
+    Request,
+    WebSocket
+)
+from fastapi.templating import Jinja2Templates
+
+import fastf1
+
+
+stream_task = None
+stream_enabled = False
+
+app = FastAPI()
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+@app.get("/")
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+@app.get("/historical")
+async def historical(season: int, round: int):
+    session = fastf1.get_session(season, round, "R")
+    session.load()
+    results = session.results.to_dict()
+    return results
+
+
+@app.post("/admin/start")
+async def admin_start():
+    global stream_enabled
+    stream_enabled = True
+    return {"status": "started"}
+
+
+@app.post("/admin/stop")
+async def admin_stop():
+    global stream_enabled
+    stream_enabled = False
+    return {"status": "stopped"}
+
+# Simple websocket streaming from example data
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    # Stream from a sample live data file as demonstration
+    path = "fastf1/testing/reference_data/livedata/2021_1_FP3.txt"
+    with open(path) as f:
+        for line in f:
+            if not stream_enabled:
+                break
+            await ws.send_text(line.strip())
+            await asyncio.sleep(0.05)
+    await ws.send_text("[stream ended]")
+    await ws.close()

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -26,6 +26,14 @@ def get_historical_results(season: int, round_: int) -> list[dict]:
     results = session.results.fillna("").astype(str)
     return results.to_dict(orient="records")
 
+
+def get_practice_laps(season: int, round_: int, session: int) -> list[dict]:
+    """Load lap times for a practice session."""
+    ses = fastf1.get_session(season, round_, f"FP{session}")
+    ses.load()
+    laps = ses.laps.fillna("").astype(str)
+    return laps.to_dict(orient="records")
+
 @app.get("/")
 async def index(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
@@ -33,6 +41,12 @@ async def index(request: Request):
 @app.get("/historical")
 async def historical(season: int, round: int):
     data = get_historical_results(season, round)
+    return jsonable_encoder(data)
+
+
+@app.get("/practice-laps")
+async def practice_laps(season: int, round: int, session: int = 1):
+    data = get_practice_laps(season, round, session)
     return jsonable_encoder(data)
 
 

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -6,6 +6,7 @@ from fastapi import (
     Request,
     WebSocket
 )
+from fastapi.encoders import jsonable_encoder
 from fastapi.templating import Jinja2Templates
 
 import fastf1
@@ -25,8 +26,8 @@ async def index(request: Request):
 async def historical(season: int, round: int):
     session = fastf1.get_session(season, round, "R")
     session.load()
-    results = session.results.to_dict()
-    return results
+    results = session.results.fillna("").astype(str)
+    return jsonable_encoder(results.to_dict(orient="records"))
 
 
 @app.post("/admin/start")

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -18,16 +18,22 @@ stream_enabled = False
 app = FastAPI()
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 
+
+def get_historical_results(season: int, round_: int) -> list[dict]:
+    """Load and format race results."""
+    session = fastf1.get_session(season, round_, "R")
+    session.load()
+    results = session.results.fillna("").astype(str)
+    return results.to_dict(orient="records")
+
 @app.get("/")
 async def index(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
 @app.get("/historical")
 async def historical(season: int, round: int):
-    session = fastf1.get_session(season, round, "R")
-    session.load()
-    results = session.results.fillna("").astype(str)
-    return jsonable_encoder(results.to_dict(orient="records"))
+    data = get_historical_results(season, round)
+    return jsonable_encoder(data)
 
 
 @app.post("/admin/start")

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+jinja2
+uvicorn[standard]

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -43,23 +43,26 @@
         function renderResults(data) {
             const container = document.getElementById('history');
             container.innerHTML = '';
+            if (!data.length) {
+                container.textContent = 'No data';
+                return;
+            }
             const table = document.createElement('table');
-            const head = document.createElement('tr');
-            for (const key of Object.keys(data.PositionText)) {
+            const headRow = document.createElement('tr');
+            for (const key of Object.keys(data[0])) {
                 const th = document.createElement('th');
                 th.textContent = key;
-                head.appendChild(th);
+                headRow.appendChild(th);
             }
-            table.appendChild(head);
-            const length = Object.values(data.PositionText).length;
-            for (let i = 0; i < length; i++) {
-                const row = document.createElement('tr');
-                for (const key of Object.keys(data.PositionText)) {
+            table.appendChild(headRow);
+            for (const rowData of data) {
+                const tr = document.createElement('tr');
+                for (const key of Object.keys(rowData)) {
                     const td = document.createElement('td');
-                    td.textContent = data[key][i];
-                    row.appendChild(td);
+                    td.textContent = rowData[key];
+                    tr.appendChild(td);
                 }
-                table.appendChild(row);
+                table.appendChild(tr);
             }
             container.appendChild(table);
         }
@@ -89,7 +92,7 @@
     Season: <input id="season" value="2023" />
     Round: <input id="round" value="1" />
     <button onclick="loadHistorical()">Load</button>
-    <pre id="history"></pre>
+    <div id="history"></div>
 </div>
 <div>
     <h2>Live Stream</h2>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>FastF1 Web</title>
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            max-width: 800px;
+            margin: auto;
+        }
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 8px;
+        }
+        th {
+            background-color: #f4f4f4;
+        }
+        #stream pre {
+            margin: 0;
+        }
+    </style>
+    <script>
+        async function loadHistorical() {
+            const season = document.getElementById('season').value;
+            const round = document.getElementById('round').value;
+            try {
+                const res = await fetch(`/historical?season=${season}&round=${round}`);
+                if (!res.ok) {
+                    throw new Error('Request failed');
+                }
+                const data = await res.json();
+                renderResults(data);
+            } catch (err) {
+                alert('Failed to load data');
+            }
+        }
+
+        function renderResults(data) {
+            const container = document.getElementById('history');
+            container.innerHTML = '';
+            const table = document.createElement('table');
+            const head = document.createElement('tr');
+            for (const key of Object.keys(data.PositionText)) {
+                const th = document.createElement('th');
+                th.textContent = key;
+                head.appendChild(th);
+            }
+            table.appendChild(head);
+            const length = Object.values(data.PositionText).length;
+            for (let i = 0; i < length; i++) {
+                const row = document.createElement('tr');
+                for (const key of Object.keys(data.PositionText)) {
+                    const td = document.createElement('td');
+                    td.textContent = data[key][i];
+                    row.appendChild(td);
+                }
+                table.appendChild(row);
+            }
+            container.appendChild(table);
+        }
+
+        let ws;
+        function startStream() {
+            document.getElementById('stream').innerHTML = '';
+            fetch('/admin/start', {method: 'POST'});
+            ws = new WebSocket(`ws://${location.host}/ws`);
+            ws.onmessage = (ev) => {
+                const pre = document.createElement('pre');
+                pre.textContent = ev.data;
+                document.getElementById('stream').appendChild(pre);
+            };
+        }
+
+        function stopStream() {
+            fetch('/admin/stop', {method: 'POST'});
+            if (ws) { ws.close(); }
+        }
+    </script>
+</head>
+<body>
+<h1>FastF1 Web</h1>
+<div>
+    <h2>Historical Data</h2>
+    Season: <input id="season" value="2023" />
+    Round: <input id="round" value="1" />
+    <button onclick="loadHistorical()">Load</button>
+    <pre id="history"></pre>
+</div>
+<div>
+    <h2>Live Stream</h2>
+    <button onclick="startStream()">Start Stream</button>
+    <button onclick="stopStream()">Stop Stream</button>
+    <div id="stream"></div>
+</div>
+</body>
+</html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -40,6 +40,50 @@
             }
         }
 
+        async function loadPractice() {
+            const season = document.getElementById('pseason').value;
+            const round = document.getElementById('pround').value;
+            const session = document.getElementById('psession').value;
+            try {
+                const url = `/practice-laps?season=${season}&round=${round}&session=${session}`;
+                const res = await fetch(url);
+                if (!res.ok) {
+                    throw new Error('Request failed');
+                }
+                const data = await res.json();
+                renderPractice(data);
+            } catch (err) {
+                alert('Failed to load data');
+            }
+        }
+
+        function renderPractice(data) {
+            const container = document.getElementById('practice');
+            container.innerHTML = '';
+            if (!data.length) {
+                container.textContent = 'No data';
+                return;
+            }
+            const table = document.createElement('table');
+            const headRow = document.createElement('tr');
+            for (const key of Object.keys(data[0])) {
+                const th = document.createElement('th');
+                th.textContent = key;
+                headRow.appendChild(th);
+            }
+            table.appendChild(headRow);
+            for (const rowData of data) {
+                const tr = document.createElement('tr');
+                for (const key of Object.keys(rowData)) {
+                    const td = document.createElement('td');
+                    td.textContent = rowData[key];
+                    tr.appendChild(td);
+                }
+                table.appendChild(tr);
+            }
+            container.appendChild(table);
+        }
+
         function renderResults(data) {
             const container = document.getElementById('history');
             container.innerHTML = '';
@@ -93,6 +137,14 @@
     Round: <input id="round" value="1" />
     <button onclick="loadHistorical()">Load</button>
     <div id="history"></div>
+</div>
+<div>
+    <h2>Practice Lap Times</h2>
+    Season: <input id="pseason" value="2023" />
+    Round: <input id="pround" value="1" />
+    Session: <input id="psession" value="1" />
+    <button onclick="loadPractice()">Load</button>
+    <div id="practice"></div>
 </div>
 <div>
     <h2>Live Stream</h2>


### PR DESCRIPTION
## Summary
- create a simple FastAPI application to expose historical race data
- stream example live timing data over WebSocket
- include admin endpoints to start/stop streaming
- minimal HTML frontend that consumes the new API
- provide Dockerfile and docker-compose to run the service
- improve web UI styling and docker configuration

## Testing
- `pre-commit run --files README.md docker-compose.yml webapp/main.py webapp/requirements.txt webapp/templates/index.html .dockerignore`
- `pytest fastf1/tests/test_api.py::test_deleted_laps_not_marked_personal_best -q`


------
https://chatgpt.com/codex/tasks/task_e_686f47073158832ab7b26d7d0226bf07