### PR TITLE
Isolate lap time API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ docs/gen_modules/
 # other data directories
 reference/
 recordings/
+lap_time_api/data/

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ Licensing B.V.
 ## Web Frontend
 
 This repository includes a small FastAPI based web application that lets you
-load historical race data, fetch practice lap times and display a demo live
-timing stream. To start the
+load historical race data and display a demo live timing stream. To start the
 service using Docker run:
 
 ```bash
@@ -85,3 +84,26 @@ docker compose up --build
 ```
 
 The UI will be available at http://localhost:8000.
+
+## Lap Time API
+
+The lap time endpoint is now provided as its own FastAPI application located in
+`lap_time_api`. The API can be started independently using Uvicorn:
+
+```bash
+uvicorn lap_time_api.main:app --reload
+```
+
+This separation allows the lap time API to run without any of the additional
+functionality used by the demo web frontend. Whenever the endpoint is queried,
+the loaded lap data is automatically stored under `lap_time_api/data/` for
+future reference.
+
+The service can also be started using Docker compose which builds the
+`lap-time-api` service defined in `docker-compose.yml`:
+
+```bash
+docker compose up --build lap-time-api
+```
+
+See [`lap_time_api/README.md`](lap_time_api/README.md) for additional details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,13 @@ services:
     environment:
       PYTHONUNBUFFERED: "1"
     restart: unless-stopped
+
+  lap-time-api:
+    build:
+      context: .
+      dockerfile: lap_time_api/Dockerfile
+    ports:
+      - "8001:8001"
+    environment:
+      PYTHONUNBUFFERED: "1"
+    restart: unless-stopped

--- a/lap_time_api/Dockerfile
+++ b/lap_time_api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir . && \
+    pip install --no-cache-dir -r lap_time_api/requirements.txt
+CMD ["uvicorn", "lap_time_api.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/lap_time_api/README.md
+++ b/lap_time_api/README.md
@@ -1,0 +1,20 @@
+# Lap Time API
+
+This directory contains a small FastAPI service that exposes lap time data.
+
+The service depends on the `fastf1` package from this repository. To run it
+locally you can use `uvicorn`:
+
+```bash
+uvicorn lap_time_api.main:app --reload
+```
+
+The service saves every response under `lap_time_api/data` for future use.
+
+A Dockerfile is provided. You can start the API using `docker compose`:
+
+```bash
+docker compose up --build lap-time-api
+```
+
+which will run the service on port 8001.

--- a/lap_time_api/main.py
+++ b/lap_time_api/main.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
+import fastf1
+import json
+from pathlib import Path
+
+app = FastAPI()
+
+
+def get_practice_laps(season: int, round_: int, session: int) -> list[dict]:
+    """Load lap times for a practice session."""
+    ses = fastf1.get_session(season, round_, f"FP{session}")
+    ses.load()
+    laps = ses.laps.fillna("").astype(str)
+    return laps.to_dict(orient="records")
+
+
+def save_practice_laps(data: list[dict], season: int, round_: int, session: int) -> None:
+    """Persist lap times to disk as JSON."""
+    out_dir = Path(__file__).resolve().parent / "data"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f"{season}_{round_}_FP{session}.json"
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def load_saved_practice_laps(season: int, round_: int, session: int) -> list[dict] | None:
+    """Load cached lap times if available."""
+    out_dir = Path(__file__).resolve().parent / "data"
+    out_file = out_dir / f"{season}_{round_}_FP{session}.json"
+    if out_file.exists():
+        with out_file.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return None
+
+
+@app.get("/practice-laps")
+async def practice_laps(season: int, round: int, session: int = 1):
+    saved = load_saved_practice_laps(season, round, session)
+    if saved is None:
+        saved = get_practice_laps(season, round, session)
+        save_practice_laps(saved, season, round, session)
+    return jsonable_encoder(saved)
+

--- a/lap_time_api/requirements.txt
+++ b/lap_time_api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -27,13 +27,6 @@ def get_historical_results(season: int, round_: int) -> list[dict]:
     return results.to_dict(orient="records")
 
 
-def get_practice_laps(season: int, round_: int, session: int) -> list[dict]:
-    """Load lap times for a practice session."""
-    ses = fastf1.get_session(season, round_, f"FP{session}")
-    ses.load()
-    laps = ses.laps.fillna("").astype(str)
-    return laps.to_dict(orient="records")
-
 @app.get("/")
 async def index(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
@@ -44,10 +37,6 @@ async def historical(season: int, round: int):
     return jsonable_encoder(data)
 
 
-@app.get("/practice-laps")
-async def practice_laps(season: int, round: int, session: int = 1):
-    data = get_practice_laps(season, round, session)
-    return jsonable_encoder(data)
 
 
 @app.post("/admin/start")

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -40,49 +40,6 @@
             }
         }
 
-        async function loadPractice() {
-            const season = document.getElementById('pseason').value;
-            const round = document.getElementById('pround').value;
-            const session = document.getElementById('psession').value;
-            try {
-                const url = `/practice-laps?season=${season}&round=${round}&session=${session}`;
-                const res = await fetch(url);
-                if (!res.ok) {
-                    throw new Error('Request failed');
-                }
-                const data = await res.json();
-                renderPractice(data);
-            } catch (err) {
-                alert('Failed to load data');
-            }
-        }
-
-        function renderPractice(data) {
-            const container = document.getElementById('practice');
-            container.innerHTML = '';
-            if (!data.length) {
-                container.textContent = 'No data';
-                return;
-            }
-            const table = document.createElement('table');
-            const headRow = document.createElement('tr');
-            for (const key of Object.keys(data[0])) {
-                const th = document.createElement('th');
-                th.textContent = key;
-                headRow.appendChild(th);
-            }
-            table.appendChild(headRow);
-            for (const rowData of data) {
-                const tr = document.createElement('tr');
-                for (const key of Object.keys(rowData)) {
-                    const td = document.createElement('td');
-                    td.textContent = rowData[key];
-                    tr.appendChild(td);
-                }
-                table.appendChild(tr);
-            }
-            container.appendChild(table);
-        }
 
         function renderResults(data) {
             const container = document.getElementById('history');
@@ -137,14 +94,6 @@
     Round: <input id="round" value="1" />
     <button onclick="loadHistorical()">Load</button>
     <div id="history"></div>
-</div>
-<div>
-    <h2>Practice Lap Times</h2>
-    Season: <input id="pseason" value="2023" />
-    Round: <input id="pround" value="1" />
-    Session: <input id="psession" value="1" />
-    <button onclick="loadPractice()">Load</button>
-    <div id="practice"></div>
 </div>
 <div>
     <h2>Live Stream</h2>


### PR DESCRIPTION
## Summary
- detach lap time service from the demo webapp
- trim webapp features to remove lap time endpoint
- document how to run the standalone lap time API
- store retrieved lap time data under `lap_time_api/data`
- provide a Docker compose service for the API

## Testing
- `pytest -q` *(fails: unrecognized arguments --xdoctest --mpl --mpl-baseline-path=fastf1/tests/mpl-baseline --mpl-results-path=mpl-results)*

------
https://chatgpt.com/codex/tasks/task_e_6870184e0748832ab15f71448f0e12fb